### PR TITLE
fix: prevent CodeQL exception information exposure

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,9 +32,9 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,40 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - testing
+  pull_request:
+    branches:
+      - testing
+  schedule:
+    - cron: "30 1 * * 1"
+
+jobs:
+  analyze:
+    name: CodeQL analysis
+    runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - python
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3

--- a/backend/app/routes/stripe.py
+++ b/backend/app/routes/stripe.py
@@ -91,10 +91,10 @@ def checkout():
         db.session.commit()
 
         return {"checkout_url": session.url}
-    except Exception as err:
+    except Exception:
         db.session.rollback()
         current_app.logger.exception("Checkout Failed")
-        return {"error", str(err)}, 500
+        return {"error": "Checkout Failed. Please Try Again Later."}, 500
 
 
 # Stripe-Should-Retry # header for idempotency


### PR DESCRIPTION
## Description
Fixes #24

Fixes the CodeQL "Information exposure through an exception" finding
in `backend/app/routes/stripe.py`.

The checkout exception handler no longer returns the raw exception
message to the client. Detailed exception information remains available
in server logs.

---

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - **What breaks?** (Describe any breaking change here)
- [ ] Documentation update

---

## How Has This Been Tested?

### Backend & Core Logic (Python / Bash)
- [x] Pytest

### Linting
- [x] Pre-commit hooks

### CI/CD
- [x] Github Actions

## Screenshots / Videos
- [ ] Added before/after screenshots if applicable

---

## Guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-reach areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings